### PR TITLE
Clusterissuer updates

### DIFF
--- a/charts/cert-manager-clusterissuer/Chart.yaml
+++ b/charts/cert-manager-clusterissuer/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart to create a cert-manager clusterissuer
 name: cert-manager-clusterissuer
-version: 0.1.0
+version: 0.2.0

--- a/charts/cert-manager-clusterissuer/templates/clusterissuer.yaml
+++ b/charts/cert-manager-clusterissuer/templates/clusterissuer.yaml
@@ -22,7 +22,12 @@ spec:
             {{ if .Values.clusterissuer.route53.hostedZoneID -}}
             hostedZoneID: {{ .Values.clusterissuer.route53.hostedZoneID }}
             {{ end -}}
+            {{ if .Values.clusterissuer.route53.role -}}
+            role: {{ .Values.clusterissuer.route53.role }}
+            {{ end -}}
+            {{ if .Values.clusterissuer.route53.accessKeyID -}}
             accessKeyID: {{ .Values.clusterissuer.route53.accessKeyID }}
             secretAccessKeySecretRef:
               name: {{ include "cert-manager-clusterissuer.fullname" . }}-secret-access-key
               key: secret-access-key
+            {{ end -}}

--- a/charts/cert-manager-clusterissuer/templates/secret.yml
+++ b/charts/cert-manager-clusterissuer/templates/secret.yml
@@ -1,3 +1,4 @@
+{{ if .Values.clusterissuer.route53.secretAccessKey -}}
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -10,4 +11,5 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 data:
-  secret-access-key: {{ .Values.clusterissuer.route53.secretAccessKeySecret | b64enc }}
+  secret-access-key: {{ .Values.clusterissuer.route53.secretAccessKey | b64enc }}
+{{ end -}}

--- a/charts/cert-manager-clusterissuer/values.yaml
+++ b/charts/cert-manager-clusterissuer/values.yaml
@@ -14,7 +14,18 @@ clusterissuer:
   # NOTE: at the moment only route53 is supported
   #
   route53:
-    region: YOUR-AWS-REGION
-    hostedZoneID: false
-    accessKeyID: YOUR-ACCESS-KEY-ID
-    secretAccessKeySecret: YOUR-ACCESS-KEY-SECRET
+    region: us-east-1
+    # Optional: you can limit by hosted zone id
+    # hostedZoneID: YOUR_HOSTED_ZONE_ID
+
+    # Optional: you can assume a role to obtain the permissions make changes to route53
+    # role: arn:aws:iam::YYYYYYYYYYYY:role/your-dns-manager-role
+
+    # Optional: you can use programmatic keys
+    # accessKeyID: YOUR_ACCESS_KEY_ID
+    # secretAccessKey: YOUR_SECRET_ACCESS_KEY
+
+    # Note: if you don't use any of the above, you still have a couple of
+    # options to get cert-manager the permissions it needs on route53
+    #   1. AWS EC2 instance instance profile
+    #   2. AWS EKS IRSA (IAM Roles for Service Accounts)


### PR DESCRIPTION
## what
* Refactor clusterissuer chart to support programmatic keys, role or neither of those.

## why
* Now the chart provides more options to deploy a clusterissuer which allows us to use alternatives that avoid exposing sensitive credentials.
