### PR TITLE
Add ingress-monitor-controller-endpoint chart

### DIFF
--- a/charts/ingress-monitor-controller-endpoint/Chart.yaml
+++ b/charts/ingress-monitor-controller-endpoint/Chart.yaml
@@ -6,6 +6,9 @@ keywords:
   - IngressMonitorController
   - kubernetes
 maintainers:
+- name: Binbash Leverage Team
+  email: leverage@binbash.com.ar
+  url: https://binbash.com.ar
 - name: Luis Gallardo
   email: luis.gallardo@binbash.com.ar
   url: https://binbash.com.ar

--- a/charts/ingress-monitor-controller-endpoint/Chart.yaml
+++ b/charts/ingress-monitor-controller-endpoint/Chart.yaml
@@ -1,5 +1,11 @@
 apiVersion: v1
-appVersion: "1.0"
-description: A Helm chart to install Ingress Monitor Controller endpoints
 name: ingress-monitor-controller-endpoint
+description: A Helm chart to install Ingress Monitor Controller endpoints
 version: 0.1.0
+keywords:
+  - IngressMonitorController
+  - kubernetes
+maintainers:
+- name: Luis Gallardo
+  email: luis.gallardo@binbash.com.ar
+  url: https://binbash.com.ar

--- a/charts/ingress-monitor-controller-endpoint/Chart.yaml
+++ b/charts/ingress-monitor-controller-endpoint/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart to install Ingress Monitor Controller endpoints
+name: ingress-monitor-controller-endpoint
+version: 0.1.0

--- a/charts/ingress-monitor-controller-endpoint/README.md
+++ b/charts/ingress-monitor-controller-endpoint/README.md
@@ -1,0 +1,24 @@
+# ingress-monitor-controller-endpoint
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square)
+
+A Helm chart to install Ingress Monitor Controller endpoints
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| Luis Gallardo | luis.gallardo@binbash.com.ar | https://binbash.com.ar |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| endpoint.forceHttps | bool | `true` |  |
+| endpoint.name | string | `"binbash.com.ar"` |  |
+| endpoint.provider.interval | int | `600` |  |
+| endpoint.provider.monitorType | string | `"http"` |  |
+| endpoint.provider.name | string | `"uptimeRobot"` |  |
+| endpoint.type | string | `"url"` |  |
+| endpoint.url | string | `"https://binbash.com.ar"` |  |
+

--- a/charts/ingress-monitor-controller-endpoint/README.md
+++ b/charts/ingress-monitor-controller-endpoint/README.md
@@ -8,6 +8,7 @@ A Helm chart to install Ingress Monitor Controller endpoints
 
 | Name | Email | Url |
 | ---- | ------ | --- |
+| Binbash Leverage Team | leverage@binbash.com.ar | https://binbash.com.ar |
 | Luis Gallardo | luis.gallardo@binbash.com.ar | https://binbash.com.ar |
 
 ## Values
@@ -15,10 +16,10 @@ A Helm chart to install Ingress Monitor Controller endpoints
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | endpoint.forceHttps | bool | `true` |  |
-| endpoint.name | string | `"binbash.com.ar"` |  |
+| endpoint.name | string | `"example.com"` |  |
 | endpoint.provider.interval | int | `600` |  |
 | endpoint.provider.monitorType | string | `"http"` |  |
 | endpoint.provider.name | string | `"uptimeRobot"` |  |
 | endpoint.type | string | `"url"` |  |
-| endpoint.url | string | `"https://binbash.com.ar"` |  |
+| endpoint.url | string | `"https://example.com"` |  |
 

--- a/charts/ingress-monitor-controller-endpoint/templates/_helpers.tpl
+++ b/charts/ingress-monitor-controller-endpoint/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ingress-monitor-controller-endpoint.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "ingress-monitor-controller-endpoint.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ingress-monitor-controller-endpoint.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "ingress-monitor-controller-endpoint.labels" -}}
+helm.sh/chart: {{ include "ingress-monitor-controller-endpoint.chart" . }}
+{{ include "ingress-monitor-controller-endpoint.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "ingress-monitor-controller-endpoint.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ingress-monitor-controller-endpoint.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "ingress-monitor-controller-endpoint.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "ingress-monitor-controller-endpoint.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/ingress-monitor-controller-endpoint/templates/endpoint.yaml
+++ b/charts/ingress-monitor-controller-endpoint/templates/endpoint.yaml
@@ -1,0 +1,34 @@
+apiVersion: endpointmonitor.stakater.com/v1alpha1
+kind: EndpointMonitor
+metadata:
+  name: {{ .Values.endpoint.name  }}
+  labels:
+    app: {{ template "ingress-monitor-controller-endpoint.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+{{- if eq .Values.endpoint.type "url"}} 
+  forceHttps: {{ .Values.endpoint.forceHttps }}
+  url: {{ .Values.endpoint.url }}
+{{end}}
+{{- if eq .Values.endpoint.type "route" }}
+  forceHttps: {{ .Values.endpoint.forceHttps }}
+  urlFrom:
+    routeRef:
+      name: { .Values.endpoint.routeName }}
+{{end}}
+{{- if eq .Values.endpoint.type "ingress" }}
+  forceHttps: {{ .Values.endpoint.forceHttps }}
+  urlFrom:
+    ingressRef:
+      name: { .Values.endpoint.ingresseName }}
+{{end}}
+{{- if .Values.endpoint.provider }}
+{{- if eq .Values.endpoint.provider.name "uptimeRobot" }}
+  providers: "uptimeRobot"
+  uptimeRobotConfig:
+    interval: {{ .Values.endpoint.provider.interval }}
+    monitorType: {{  .Values.endpoint.provider.monitorType }}
+{{end}}
+{{end}}

--- a/charts/ingress-monitor-controller-endpoint/values.yaml
+++ b/charts/ingress-monitor-controller-endpoint/values.yaml
@@ -2,10 +2,10 @@
 # EndpointMonitor
 #
 endpoint:
-  name: binbash.com.ar
+  name: example.com
   type: url
   forceHttps: true
-  url: https://binbash.com.ar
+  url: https://example.com
   provider: 
     name: uptimeRobot
     interval: 600

--- a/charts/ingress-monitor-controller-endpoint/values.yaml
+++ b/charts/ingress-monitor-controller-endpoint/values.yaml
@@ -1,0 +1,13 @@
+#
+# EndpointMonitor
+#
+endpoint:
+  name: binbash.com.ar
+  type: url
+  forceHttps: true
+  url: https://binbash.com.ar
+  provider: 
+    name: uptimeRobot
+    interval: 600
+    monitorType: http
+

--- a/charts/ingress-monitor-controller/Chart.yaml
+++ b/charts/ingress-monitor-controller/Chart.yaml
@@ -10,6 +10,9 @@ icon: https://raw.githubusercontent.com/stakater/IngressMonitorController/master
 sources:
 - https://github.com/stakater/IngressMonitorController
 maintainers:
+- name: Binbash Leverage Team
+  email: leverage@binbash.com.ar
+  url: https://binbash.com.ar
 - name: Luis Gallardo
   email: luis.gallardo@binbash.com.ar
   url: https://binbash.com.ar

--- a/charts/ingress-monitor-controller/README.md
+++ b/charts/ingress-monitor-controller/README.md
@@ -10,6 +10,7 @@ Ingress Monitor Controller chart that runs on kubernetes
 
 | Name | Email | Url |
 | ---- | ------ | --- |
+| Binbash Leverage Team | leverage@binbash.com.ar | https://binbash.com.ar |
 | Luis Gallardo | luis.gallardo@binbash.com.ar | https://binbash.com.ar |
 
 ## Source Code


### PR DESCRIPTION
## what
* Add Ingress Monitor Controller Endpoint chart  

## why
* As a workaround for deploying IMC EnpointMonitor custom resources for K8s

## references
* [Ingress Monitor Controller](https://github.com/stakater/IngressMonitorController)
* [Add Monitor](https://github.com/stakater/IngressMonitorController#add-endpointmonitor)


