### PR TITLE
Upgrade clusterissuer chart to support v1 api version

### DIFF
--- a/charts/cert-manager-clusterissuer/Chart.yaml
+++ b/charts/cert-manager-clusterissuer/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart to create a cert-manager clusterissuer
 name: cert-manager-clusterissuer
-version: 0.2.0
+version: 0.3.0

--- a/charts/cert-manager-clusterissuer/templates/clusterissuer.yaml
+++ b/charts/cert-manager-clusterissuer/templates/clusterissuer.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1beta1
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: {{ include "cert-manager-clusterissuer.fullname" . }}


### PR DESCRIPTION
## what
* Upgrade clusterissuer chart to support v1 api version

## why
* This is needed by more recent versions of Cert-Manager