### PR TITLE
Add k8s-image-availability-exporter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,7 +205,7 @@ jobs:
 # configuration elements, including jobs, commands, and executors.
 #
 orbs:
-  sumologic: circleci/sumologic@1.0.6
+  # sumologic: circleci/sumologic@1.0.6
   slack: circleci/slack@4.1.1
 
 #
@@ -227,5 +227,5 @@ workflows:
             branches:
              only: # only branches matching the below regex filters will run
                - master
-      - sumologic/workflow-collector:
-          context: binbashar-org-global-context
+      # - sumologic/workflow-collector:
+      #     context: binbashar-org-global-context

--- a/charts/k8s-image-availability-exporter/Chart.yaml
+++ b/charts/k8s-image-availability-exporter/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "v0.5.1"
+description: Application for monitoring the cluster workloads image presence in docker registry.
+name: k8s-image-availability-exporter
+version: "0.5.1"

--- a/charts/k8s-image-availability-exporter/README.md
+++ b/charts/k8s-image-availability-exporter/README.md
@@ -1,0 +1,65 @@
+# k8s-image-availability-exporter
+
+## Introduction
+
+This chart bootstraps a [k8s-image-availability-exporter](https://github.com/flant/k8s-image-availability-exporter) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+  - Kubernetes 1.12+
+  - Helm 2+
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+helm repo add flant_common_github https://charts.flant.com/common/github
+helm repo update
+helm install my-release flant_common_github/k8s-image-availability-exporter
+```
+
+The command deploys k8s-image-availability-exporter on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+The default installation includes only the deployment, service, and rbac configuration.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following tables list the configurable parameters of the k8s-image-availability-exporter chart and their default values.
+
+### General
+| Parameter | Description | Default |
+| ----- | ----------- | ------ |
+| `k8sImageAvailabilityExporter.image.pullPolicy` | Image pull policy to use for the k8s-image-availability-exporter deployment | `IfNotPresent` |
+| `k8sImageAvailabilityExporter.image.repository` | Repository to use for the k8s-image-availability-exporter deployment | `flant/k8s-image-availability-exporter` |
+| `k8sImageAvailabilityExporter.image.tag` | Tag to use for the k8s-image-availability-exporter deployment | `v0.1.13` |
+| `k8sImageAvailabilityExporter.replicas` | Number of instances to deploy for a k8s-image-availability-exporter deployment. | `1` |
+| `k8sImageAvailabilityExporter.resources` | Resource limits for k8s-image-availability-exporter | `{}` |
+| `serviceMonitor.enabled` | Create [Prometheus Operator](https://github.com/coreos/prometheus-operator) serviceMonitor resource | `false` |
+| `serviceMonitor.interval` | Scrape interval for serviceMonitor | `15s` |
+| `prometheusRule.enabled` | Create [Prometheus Operator](https://github.com/coreos/prometheus-operator) prometheusRule resource | `false` |
+| `prometheusRule.defaultGroupsEnabled` | Setup default alerts (works only if prometheusRule.enabled is set to true) | `true` |
+| `prometheusRule.additionalGroups` | Additional PrometheusRule groups | `[]` |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+helm install my-release k8s-image-availability-exporter --set k8sImageAvailabilityExporter.replicas=2
+```
+
+Alternatively, one or more YAML files that specify the values for the above parameters can be provided while installing the chart. For example,
+
+```bash
+helm install my-release k8s-image-availability-exporter -f values1.yaml,values2.yaml
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)

--- a/charts/k8s-image-availability-exporter/templates/_helpers.tpl
+++ b/charts/k8s-image-availability-exporter/templates/_helpers.tpl
@@ -1,0 +1,34 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "k8s-image-availability-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+And depending on the resources the name is completed with an extension.
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "k8s-image-availability-exporter.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "k8s-image-availability-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/k8s-image-availability-exporter/templates/deployment.yaml
+++ b/charts/k8s-image-availability-exporter/templates/deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "k8s-image-availability-exporter.fullname" . }}
+  labels:
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app.kubernetes.io/name: "{{ template "k8s-image-availability-exporter.fullname" . }}"
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    app.kubernetes.io/component: monitoring
+spec:
+  replicas: {{ .Values.k8sImageAvailabilityExporter.replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "k8s-image-availability-exporter.fullname" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "k8s-image-availability-exporter.fullname" . }}
+    spec:
+      containers:
+      - name: k8s-image-availability-exporter
+        {{- if .Values.k8sImageAvailabilityExporter.args }}
+        args:
+        {{- range .Values.k8sImageAvailabilityExporter.args }}
+          - {{ . }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.k8sImageAvailabilityExporter.env }}
+        env:
+        {{- range .Values.k8sImageAvailabilityExporter.env }}
+          - name: {{ .name }}
+            value: {{ .value }}
+        {{- end }}
+        {{- end }}
+        ports:
+        - containerPort: 8080
+          name: http
+        image: {{ .Values.k8sImageAvailabilityExporter.image.repository }}:{{ .Values.k8sImageAvailabilityExporter.image.tag }}
+        imagePullPolicy: {{ .Values.k8sImageAvailabilityExporter.image.imagePullPolicy }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: http
+            scheme: HTTP
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: http
+            scheme: HTTP
+        resources:
+        {{ if .Values.k8sImageAvailabilityExporter.resources }}
+{{ .Values.k8sImageAvailabilityExporter.resources | toYaml | indent 10}}
+        {{ end }}
+      serviceAccountName: {{ template "k8s-image-availability-exporter.fullname" . }}

--- a/charts/k8s-image-availability-exporter/templates/prometheus-rule.yaml
+++ b/charts/k8s-image-availability-exporter/templates/prometheus-rule.yaml
@@ -1,0 +1,69 @@
+{{- if .Values.prometheusRule.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ template "k8s-image-availability-exporter.fullname" . }}
+spec:
+  groups:
+{{- if .Values.prometheusRule.defaultGroupsEnabled }}
+  - name: k8s-image-availability-exporter.rules
+    rules:
+    - alert: DeploymentImageUnavailable
+      expr: |
+        max by (namespace, deployment, container, image) (
+          k8s_image_availability_exporter_deployment_available == 0
+        )
+      annotations:
+        message: >
+          Image {{`{{ $labels.image }}`}} from container {{`{{ $labels.container }}`}}
+          in deployment {{`{{ $labels.deployment }}`}}
+          from namespace {{`{{ $labels.namespace }}`}}
+          is not available in docker registry.
+      labels:
+        severity: critical
+    - alert: StatefulSetImageUnavailable
+      expr: |
+        max by (namespace, statefulset, container, image) (
+          k8s_image_availability_exporter_statefulset_available == 0
+        )
+      annotations:
+        message: >
+          Image {{`{{ $labels.image }}`}} from container {{`{{ $labels.container }}`}}
+          in statefulSet {{`{{ $labels.statefulset }}`}}
+          from namespace {{`{{ $labels.namespace }}`}}
+          is not available in docker registry.
+      labels:
+        severity: critical
+    - alert: DaemonSetImageUnavailable
+      expr: |
+        max by (namespace, daemonset, container, image) (
+          k8s_image_availability_exporter_daemonset_available == 0
+        )
+      annotations:
+        message: >
+          Image {{`{{ $labels.image }}`}} from container {{`{{ $labels.container }}`}}
+          in daemonSet {{`{{ $labels.daemonset }}`}}
+          from namespace {{`{{ $labels.namespace }}`}}
+          is not available in docker registry.
+      labels:
+        severity: critical
+    - alert: CronJobImageUnavailable
+      expr: |
+        max by (namespace, cronjob, container, image) (
+          k8s_image_availability_exporter_cronjob_available == 0
+        )
+      annotations:
+        message: >
+          Image {{`{{ $labels.image }}`}} from container {{`{{ $labels.container }}`}}
+          in cronJob {{`{{ $labels.cronjob }}`}}
+          from namespace {{`{{ $labels.namespace }}`}}
+          is not available in docker registry.
+      labels:
+        severity: critical
+{{- end }}
+
+{{- if .Values.prometheusRule.additionalGroups }}
+{{ .Values.prometheusRule.additionalGroups | toYaml | indent 2}}
+{{- end }}
+
+{{- end }}

--- a/charts/k8s-image-availability-exporter/templates/rbac.yaml
+++ b/charts/k8s-image-availability-exporter/templates/rbac.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "k8s-image-availability-exporter.fullname" . }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - list
+      - watch
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - list
+      - watch
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+      - apps
+    resources:
+      - deployments
+      - daemonsets
+      - statefulsets
+    verbs:
+      - list
+      - watch
+      - get
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+    verbs:
+      - list
+      - watch
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "k8s-image-availability-exporter.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "k8s-image-availability-exporter.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "k8s-image-availability-exporter.fullname" . }}
+    namespace: {{ .Release.Namespace }}

--- a/charts/k8s-image-availability-exporter/templates/service-account.yaml
+++ b/charts/k8s-image-availability-exporter/templates/service-account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "k8s-image-availability-exporter.fullname" . }}

--- a/charts/k8s-image-availability-exporter/templates/service-monitor.yaml
+++ b/charts/k8s-image-availability-exporter/templates/service-monitor.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "k8s-image-availability-exporter.fullname" . }}
+  labels:
+    app: {{ template "k8s-image-availability-exporter.fullname" . }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "k8s-image-availability-exporter.fullname" . }}
+  endpoints:
+  - port: http
+    interval: {{ .Values.serviceMonitor.interval }}
+{{- end }}

--- a/charts/k8s-image-availability-exporter/templates/service.yaml
+++ b/charts/k8s-image-availability-exporter/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "k8s-image-availability-exporter.fullname" . }}
+  labels:
+    app: {{ template "k8s-image-availability-exporter.fullname" . }}
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: http
+  selector:
+    app: {{ template "k8s-image-availability-exporter.fullname" . }}

--- a/charts/k8s-image-availability-exporter/values.yaml
+++ b/charts/k8s-image-availability-exporter/values.yaml
@@ -1,0 +1,18 @@
+k8sImageAvailabilityExporter:
+  image:
+    repository: registry.deckhouse.io/k8s-image-availability-exporter/k8s-image-availability-exporter
+    tag: v0.5.1
+    pullPolicy: IfNotPresent
+  replicas: 1
+  resources: {}
+  args:
+    - --bind-address=:8080
+  
+serviceMonitor:
+  enabled: false
+  interval: 15s
+
+prometheusRule:
+  enabled: false
+  defaultGroupsEnabled: true
+  additionalGroups: []


### PR DESCRIPTION
## what
* Add k8s-image-availability-exporter

## why
* Monitoring image availability is useful to anticipate possible missing images during cluster upgrades or even when new nodes are added to the cluster.

## references
N/A