### PR TITLE
Add pod annotations support to k8s-image-availability-exporter

### DIFF
--- a/charts/k8s-image-availability-exporter/templates/deployment.yaml
+++ b/charts/k8s-image-availability-exporter/templates/deployment.yaml
@@ -18,6 +18,10 @@ spec:
     metadata:
       labels:
         app: {{ template "k8s-image-availability-exporter.fullname" . }}
+{{- if .Values.k8sImageAvailabilityExporter.podAnnotations }}
+      annotations:
+{{ toYaml .Values.k8sImageAvailabilityExporter.podAnnotations | indent 8 }}
+{{- end }}
     spec:
       containers:
       - name: k8s-image-availability-exporter


### PR DESCRIPTION
## what
* Add pod annotations support to k8s-image-availability-exporter

## why
* We need to integrate this with Datadog Agent which can be configured via annotations

## references
N/A